### PR TITLE
Fix missing timestamp handling

### DIFF
--- a/shared/repositories/author_repository.py
+++ b/shared/repositories/author_repository.py
@@ -29,7 +29,10 @@ class AuthorRepository:
         )
 
         # Compare and return the latest of the two timestamps
-        return max(filter(None, [latest_author_change, latest_pub_change]))
+        timestamps = [t for t in (latest_author_change, latest_pub_change) if t]
+        if not timestamps:
+            return None
+        return max(timestamps)
 
     def get_authors_needing_refresh(self, num_authors=1):
         """


### PR DESCRIPTION
## Summary
- avoid crashing when author and publication timestamps are missing in `AuthorRepository.get_author_last_modification`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68559d953554832087352028848c4c45