### PR TITLE
Make record_recent_author atomic via Firestore transaction

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -135,9 +135,9 @@ Findings from a full codebase audit, ordered by priority. See `docs/codebase-rev
 
 - [x] ~~**Move plot generation out of the request thread**~~ _(resolved: matplotlib removed, charts now render client-side via Plotly.js)_
 
-- [ ] **Make `record_recent_author` atomic** _(audit §6)_
-  - `frontend/cache.py:138-171` does read-modify-write on the `v3_recent_authors` document without a transaction; concurrent requests can clobber each other and lose recent-author entries.
-  - **Fix:** Wrap the update in a Firestore transaction, or switch to per-author docs + server timestamps and query top-N.
+- [x] **Make `record_recent_author` atomic** _(audit §6)_
+  - `frontend/cache.py` — `record_recent_author` now wraps the read-modify-write in a `@firestore.transactional` block. The transactional read uses `doc_ref.get(transaction=...)` and the write goes through `transaction.set(doc_ref, ...)`, so concurrent requests cannot clobber each other.
+  - **Tests:** `frontend/tests/test_cache.py` — 7 tests cover the transactional path (empty doc, existing list, move-to-front, truncation, corrupted non-list data, exception handling, one transaction per call).
 
 - [ ] **Clean up stale author-search index chunks on rebuild** _(audit §7)_
   - `author_search/search_service.py:54-61` writes new `chunk_N` docs but never deletes old ones. If the author count shrinks, leftover chunks past the new count remain in Firestore, and `_load_index_from_firestore` iterates past the new end until it hits a gap — surfacing stale/deleted records.

--- a/frontend/cache.py
+++ b/frontend/cache.py
@@ -140,6 +140,9 @@ class FirestoreCache:
 
         Maintains a list of the most recently queried authors in Firestore,
         ordered by query time (most recent first). Deduplicates by scholar_id.
+
+        The read-modify-write is wrapped in a Firestore transaction so that
+        concurrent requests cannot clobber each other and lose entries.
         """
         entry = {
             "scholar_id": author_stats.get("scholar_id"),
@@ -154,10 +157,20 @@ class FirestoreCache:
         if not entry["scholar_id"]:
             return
 
-        try:
-            current = self.get(RECENT_AUTHORS_COLLECTION, RECENT_AUTHORS_DOC_ID)
-            if not isinstance(current, list):
-                current = []
+        doc_ref = (
+            self.db.collection(RECENT_AUTHORS_COLLECTION)
+            .document(RECENT_AUTHORS_DOC_ID)
+        )
+
+        @firestore.transactional
+        def _update(transaction):
+            snapshot = doc_ref.get(transaction=transaction)
+            current = []
+            if snapshot.exists:
+                data = snapshot.to_dict() or {}
+                existing = data.get("data")
+                if isinstance(existing, list):
+                    current = existing
 
             # Remove existing entry for this author (if any) to move to front
             current = [a for a in current if a.get("scholar_id") != entry["scholar_id"]]
@@ -166,6 +179,12 @@ class FirestoreCache:
             current = [entry] + current
             current = current[:MAX_RECENT_AUTHORS]
 
-            self.set(RECENT_AUTHORS_COLLECTION, RECENT_AUTHORS_DOC_ID, current)
+            transaction.set(doc_ref, {
+                "timestamp": datetime.now(timezone.utc),
+                "data": current,
+            })
+
+        try:
+            _update(self.db.transaction())
         except (GoogleAPICallError, RetryError, ValueError):
             logger.exception("Failed to record recent author: %s", entry.get("scholar_id"))

--- a/frontend/tests/test_cache.py
+++ b/frontend/tests/test_cache.py
@@ -2,6 +2,7 @@
 
 from unittest import mock
 
+import pytest
 from google.api_core.exceptions import ServiceUnavailable
 
 from frontend.cache import FirestoreCache, MAX_RECENT_AUTHORS
@@ -26,34 +27,67 @@ def _author(scholar_id, name="Author"):
 
 
 class TestRecordRecentAuthor:
+    """Tests for the transactional recent-author tracker.
+
+    `record_recent_author` uses `@firestore.transactional`, which requires
+    a real Transaction instance to run the retry loop. We patch the
+    decorator with a passthrough so the wrapped function runs directly
+    against the mocked transaction, then assert that reads and writes go
+    through the transaction (not the plain document reference).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _passthrough_transactional(self):
+        with mock.patch(
+            "frontend.cache.firestore.transactional",
+            side_effect=lambda fn: fn,
+        ):
+            yield
+
+    @staticmethod
+    def _setup_transaction(client, existing=None):
+        """Wire client mocks so the transactional reader sees `existing`.
+
+        Returns (transaction_mock, doc_ref_mock) for assertions.
+        """
+        doc_ref = client.collection.return_value.document.return_value
+        snapshot = mock.MagicMock()
+        if existing is None:
+            snapshot.exists = False
+        else:
+            snapshot.exists = True
+            snapshot.to_dict.return_value = {"data": existing}
+        doc_ref.get.return_value = snapshot
+
+        transaction = mock.MagicMock(name="transaction")
+        client.transaction.return_value = transaction
+        return transaction, doc_ref
+
     def test_adds_author_to_empty_list(self):
         cache, client = _make_cache()
-
-        # Simulate empty recent list
-        doc_mock = mock.MagicMock()
-        doc_mock.exists = False
-        client.collection.return_value.document.return_value.get.return_value = doc_mock
+        transaction, doc_ref = self._setup_transaction(client, existing=None)
 
         cache.record_recent_author(_author("a1", "Alice"))
 
-        # Verify set was called with list containing the author
-        client.collection.return_value.document.return_value.set.assert_called_once()
-        written = client.collection.return_value.document.return_value.set.call_args[0][0]
-        assert len(written["data"]) == 1
-        assert written["data"][0]["scholar_id"] == "a1"
+        # Read must go through the transaction (transactional read).
+        doc_ref.get.assert_called_once_with(transaction=transaction)
+        # Write must go through the transaction, not doc_ref.set directly.
+        doc_ref.set.assert_not_called()
+        transaction.set.assert_called_once()
+        written_ref, written_payload = transaction.set.call_args[0]
+        assert written_ref is doc_ref
+        assert len(written_payload["data"]) == 1
+        assert written_payload["data"][0]["scholar_id"] == "a1"
+        assert "timestamp" in written_payload
 
     def test_moves_existing_author_to_front(self):
         cache, client = _make_cache()
-
         existing = [_author("a2", "Bob"), _author("a1", "Alice")]
-        doc_mock = mock.MagicMock()
-        doc_mock.exists = True
-        doc_mock.to_dict.return_value = {"data": existing}
-        client.collection.return_value.document.return_value.get.return_value = doc_mock
+        transaction, _ = self._setup_transaction(client, existing=existing)
 
         cache.record_recent_author(_author("a1", "Alice Updated"))
 
-        written = client.collection.return_value.document.return_value.set.call_args[0][0]
+        written = transaction.set.call_args[0][1]
         assert written["data"][0]["scholar_id"] == "a1"
         assert written["data"][0]["name"] == "Alice Updated"
         assert written["data"][1]["scholar_id"] == "a2"
@@ -61,26 +95,56 @@ class TestRecordRecentAuthor:
 
     def test_truncates_to_max(self):
         cache, client = _make_cache()
-
         existing = [_author(f"a{i}") for i in range(MAX_RECENT_AUTHORS)]
-        doc_mock = mock.MagicMock()
-        doc_mock.exists = True
-        doc_mock.to_dict.return_value = {"data": existing}
-        client.collection.return_value.document.return_value.get.return_value = doc_mock
+        transaction, _ = self._setup_transaction(client, existing=existing)
 
         cache.record_recent_author(_author("new", "New Author"))
 
-        written = client.collection.return_value.document.return_value.set.call_args[0][0]
+        written = transaction.set.call_args[0][1]
         assert len(written["data"]) == MAX_RECENT_AUTHORS
         assert written["data"][0]["scholar_id"] == "new"
 
     def test_skips_if_no_scholar_id(self):
         cache, client = _make_cache()
+        self._setup_transaction(client, existing=None)
+
         cache.record_recent_author({"name": "No ID"})
+
+        # No transaction opened, no read, no write.
+        client.transaction.assert_not_called()
         client.collection.return_value.document.return_value.set.assert_not_called()
+
+    def test_ignores_non_list_existing_data(self):
+        cache, client = _make_cache()
+        doc_ref = client.collection.return_value.document.return_value
+        snapshot = mock.MagicMock()
+        snapshot.exists = True
+        snapshot.to_dict.return_value = {"data": "corrupted"}
+        doc_ref.get.return_value = snapshot
+        transaction = mock.MagicMock(name="transaction")
+        client.transaction.return_value = transaction
+
+        cache.record_recent_author(_author("a1", "Alice"))
+
+        written = transaction.set.call_args[0][1]
+        assert len(written["data"]) == 1
+        assert written["data"][0]["scholar_id"] == "a1"
 
     def test_handles_exception_gracefully(self):
         cache, client = _make_cache()
-        client.collection.return_value.document.return_value.get.side_effect = ServiceUnavailable("boom")
+        transaction = mock.MagicMock(name="transaction")
+        client.transaction.return_value = transaction
+        doc_ref = client.collection.return_value.document.return_value
+        doc_ref.get.side_effect = ServiceUnavailable("boom")
+
         # Should not raise
         cache.record_recent_author(_author("a1"))
+
+    def test_opens_a_new_transaction_per_call(self):
+        cache, client = _make_cache()
+        self._setup_transaction(client, existing=None)
+
+        cache.record_recent_author(_author("a1", "Alice"))
+        cache.record_recent_author(_author("a2", "Bob"))
+
+        assert client.transaction.call_count == 2


### PR DESCRIPTION
## Summary

- Wrap `record_recent_author`'s read-modify-write on `v3_recent_authors` in `@firestore.transactional` so concurrent requests can no longer clobber each other and lose recent-author entries (audit §6).
- The snapshot read now uses `doc_ref.get(transaction=transaction)` and the updated list is written via `transaction.set(doc_ref, ...)`, keeping both sides of the operation inside the same transaction.
- Refactor the `TestRecordRecentAuthor` suite to exercise the transactional path (reads through the transaction, writes through `transaction.set`) via an autouse fixture that patches `firestore.transactional` to a passthrough. Adds two new tests covering corrupted non-list cached data and new-transaction-per-call.

## Test plan

- [x] `python -m pytest frontend/tests/test_cache.py -v` — 7/7 passing
- [x] `python -m pytest frontend/tests/ -q` — 47/47 passing

https://claude.ai/code/session_017vYrLakban3SeUBn2TBGMD